### PR TITLE
Update pytorch_gpt2_codegen.ipynb

### DIFF
--- a/pytorch_gpt2_codegen.ipynb
+++ b/pytorch_gpt2_codegen.ipynb
@@ -23,7 +23,7 @@
       "outputs": [],
       "source": [
         "# installation\n",
-        "!pip install transformers[torch] datasets\n",
+        "!pip install transformers[torch] datasets==2.19.1\n",
         "!pip install accelerate -U"
       ]
     },


### PR DESCRIPTION
Specified `datasets` version to 2.19.1 to avoid `trust_remote_code` not supported error.