### PR TITLE
fixed hugging face dataset fetch error

### DIFF
--- a/pytorch_gpt2_codegen.ipynb
+++ b/pytorch_gpt2_codegen.ipynb
@@ -62,8 +62,8 @@
       },
       "outputs": [],
       "source": [
-        "code_dataset_train = load_dataset(\"code_search_net\", \"python\", split=\"train\", trust_remote_code=True)\n",
-        "code_dataset_validation = load_dataset(\"code_search_net\", \"python\", split=\"validation\")\n",
+        "code_dataset_train = load_dataset(\"code-search-net/code_search_net\", \"python\", split=\"train\", trust_remote_code=True)\n",
+        "code_dataset_validation = load_dataset(\"code-search-net/code_search_net\", \"python\", split=\"validation\")\n",
         "\n",
         "print(f\"total training samples: {code_dataset_train.num_rows}\")\n",
         "print(f\"total validation samples: {code_dataset_validation.num_rows}\")\n",


### PR DESCRIPTION
Fixed dataset loading error caused by the update of Hugging Face datasets.
Original data loading codes yield the following errors:
`HfUriError: Invalid HF URI 'hf://datasets/code_search_net@bd0cf261e357a3eb5c8fba490d23ec1a1cd59555/all/train-*'. Repository id must be 'namespace/name', got 'code_search_net'.`

In this pull request, the dataset path is changed to be specified with the full path.